### PR TITLE
One ")" is missing in the loadUrls function

### DIFF
--- a/progweb/ajax_chaining.md
+++ b/progweb/ajax_chaining.md
@@ -16,7 +16,7 @@ A partir du [code HTML donné](resources/jqueryAjaxChaining.html) , ajoutez jQue
  */
 const loadUrls = urls => {  
   let results = [];
-  urls.forEach(url => results.push($.ajax({url}));
+  urls.forEach(url => results.push($.ajax({url})));
   return Promise.all(results);  
 }
 ```


### PR DESCRIPTION
J'ai l'impression qu'il manque une parenthèse dans la fonction loadUrls().